### PR TITLE
fix: aws_lb_listener.https_forward 리소스 lb_arn 참조 오류 수정

### DIFF
--- a/terraform/network/lb.tf
+++ b/terraform/network/lb.tf
@@ -18,7 +18,7 @@ resource "aws_alb" "staging" {
 }
 
 resource "aws_lb_listener" "https_forward" {
-  load_balancer_arn = aws_alb.staging.id
+  load_balancer_arn = aws_alb.staging.arn
   port              = 443
   protocol          = "HTTPS"
   certificate_arn   = aws_acm_certificate.cert.arn


### PR DESCRIPTION
안녕하세요~
지나가는 개발자 입니다.

회사에서 ECS 관리 도구로 [AWS Copilot](https://aws.github.io/copilot-cli/) 을 사용하다가, 최근 Terraform 으로 옮기고 있는데요.
이 프로젝트를 보면서 많은 도움을 받고 있어서 먼저 감사의 말씀 드립니다!!

참고하며 보다가 LB 세팅에 오타를 발견하여 PR 생성합니다.

감사합니다~!